### PR TITLE
Fix VS solution and minor bug fix in device enumeration path

### DIFF
--- a/chatter/chatter.c
+++ b/chatter/chatter.c
@@ -38,6 +38,10 @@ RegisterDevices(
         }
 
         DeviceName = GetDeviceInstancePath(Device);
+        if (DeviceName == NULL) {
+            continue;
+        }
+
         Register = TRUE;
         if (!AppConfig.UseVendorSpecificHidDevices &&
             Device->dwType == RIM_TYPEHID &&

--- a/chatter/chatter.vcxproj
+++ b/chatter/chatter.vcxproj
@@ -23,7 +23,7 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{bf3c8448-6170-43fb-824d-ec7f96334d9d}</ProjectGuid>
     <RootNamespace>chatter</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -90,7 +90,8 @@
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
-      <AdditionalIncludeDirectories>D:\doc\git\chattering\chatter-cli\chatter-cli\chatter\external\argparse;D:\doc\git\chattering\chatter-cli\chatter-cli\chatter\external\clib\list\src;D:\doc\git\chattering\chatter-cli\chatter-cli\chatter\external\usb-hid-usage;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)\external\argparse;$(ProjectDir)\external\clib\list\src;$(ProjectDir)\external\usb-hid-usage;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -108,7 +109,8 @@
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
-      <AdditionalIncludeDirectories>D:\doc\git\chattering\chatter-cli\chatter-cli\chatter\external\argparse;D:\doc\git\chattering\chatter-cli\chatter-cli\chatter\external\clib\list\src;D:\doc\git\chattering\chatter-cli\chatter-cli\chatter\external\usb-hid-usage;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)\external\argparse;$(ProjectDir)\external\clib\list\src;$(ProjectDir)\external\usb-hid-usage;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -166,6 +168,7 @@
     <ClInclude Include="chatter.h" />
     <ClInclude Include="config.h" />
     <ClInclude Include="devicelist.h" />
+    <ClInclude Include="external\clib\list\src\list.h" />
     <ClInclude Include="hid.h" />
     <ClInclude Include="keyboard.h" />
     <ClInclude Include="mouse.h" />

--- a/chatter/chatter.vcxproj.filters
+++ b/chatter/chatter.vcxproj.filters
@@ -89,5 +89,8 @@
     <ClInclude Include="timer.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="external\clib\list\src\list.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/chatter/chatter.vcxproj.user
+++ b/chatter/chatter.vcxproj.user
@@ -1,11 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <LocalDebuggerCommandArguments>-c</LocalDebuggerCommandArguments>
+    <LocalDebuggerCommandArguments>
+    </LocalDebuggerCommandArguments>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <LocalDebuggerCommandArguments>-m --cursor</LocalDebuggerCommandArguments>
+    <LocalDebuggerCommandArguments>
+    </LocalDebuggerCommandArguments>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
   </PropertyGroup>
 </Project>

--- a/chatter/hid.c
+++ b/chatter/hid.c
@@ -118,8 +118,9 @@ DumpHid(
         }
         printf("\n");
 
-        printf("%-*s: %d\n", HID_ALIGN,
-            "ButtonCaps ReportCount", ButtonCaps->ReportCount);
+        // Only available in newer WDK
+        // printf("%-*s: %d\n", HID_ALIGN,
+        //    "ButtonCaps ReportCount", ButtonCaps->ReportCount);
 
         if (ButtonCaps->IsRange) {
             printf("%-*s: [%d, %d]\n", HID_ALIGN,


### PR DESCRIPTION
* VS solution lib paths to be relative to project
* Use -MT flag so that running this doesn't require the redistributables
* Small updates for better fail checks when enumerating device list