### PR TITLE
Fix bug with multiple simultaneous hid button presses

### DIFF
--- a/chatter/hid.c
+++ b/chatter/hid.c
@@ -917,7 +917,7 @@ ProcessHidEvent(
                 UsageCount += 1) {
 
                 Usage = ButtonCapState->UsageMin + UsageCount;
-                Identifier = (Count << 16) || (Usage);
+                Identifier = (Count << 16) | (Usage);
 
                 // OFF -> ON rising edge, start the timer
                 if (!ButtonCapState->PreviousState[UsageCount] &&


### PR DESCRIPTION
When multiple hid buttons were held down, IDs used for the timer wheel were wrong, resulting in incorrect duration data.